### PR TITLE
Fix test flushing all redis databases

### DIFF
--- a/tests/redis.ts
+++ b/tests/redis.ts
@@ -3,7 +3,7 @@ import Redis from 'ioredis';
 let rc = new Redis({ db: 15 });
 
 beforeEach((done) => {
-    rc.flushall(done);
+    rc.flushdb(done);
 });
 afterAll(() => {
     rc.disconnect();


### PR DESCRIPTION
It should be `flushdb` instead of `flushall`. Currently it flushes all databases instead of just database #15.